### PR TITLE
feat: Sync codegen behavior implementation

### DIFF
--- a/packages/appsync-modelgen-plugin/package.json
+++ b/packages/appsync-modelgen-plugin/package.json
@@ -27,7 +27,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^1.18.8",
+    "@graphql-codegen/plugin-helpers": "^3.1.2",
     "@graphql-codegen/visitor-plugin-common": "^1.22.0",
     "@graphql-tools/utils": "^6.0.18",
     "chalk": "^3.0.0",

--- a/packages/appsync-modelgen-plugin/src/index.ts
+++ b/packages/appsync-modelgen-plugin/src/index.ts
@@ -5,8 +5,12 @@ export interface AppSyncModelPluginConfig extends RawDocumentsConfig {
 }
 
 export * from './plugin';
+export * from './pluginSync';
 export * from './preset';
+export * from './presetSync';
 export * from './interfaces/introspection';
+
+export { SyncTypes } from './syncTypes';
 
 export const addToSchema = (config: AppSyncModelPluginConfig) => {
   const result: string[] = [];

--- a/packages/appsync-modelgen-plugin/src/pluginSync.ts
+++ b/packages/appsync-modelgen-plugin/src/pluginSync.ts
@@ -1,0 +1,68 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { GraphQLSchema, parse, visit } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { AppSyncSwiftVisitor } from './visitors/appsync-swift-visitor';
+import { RawAppSyncModelConfig } from './visitors/appsync-visitor';
+import { AppSyncJSONVisitor } from './visitors/appsync-json-metadata-visitor';
+import { AppSyncModelJavaVisitor } from './visitors/appsync-java-visitor';
+import { AppSyncModelTypeScriptVisitor } from './visitors/appsync-typescript-visitor';
+import { AppSyncModelJavascriptVisitor } from './visitors/appsync-javascript-visitor';
+import { AppSyncModelDartVisitor } from './visitors/appsync-dart-visitor';
+import { AppSyncModelIntrospectionVisitor } from './visitors/appsync-model-introspection-visitor';
+import { SyncTypes } from './syncTypes';
+type PluginSync = {
+  plugin: SyncTypes.PluginFunction<RawAppSyncModelConfig>
+}
+
+export const pluginSync: PluginSync = {
+  plugin:  (
+    schema: GraphQLSchema,
+    rawDocuments: Types.DocumentFile[],
+    config: RawAppSyncModelConfig,
+  ) => {
+    let visitor;
+    switch (config.target) {
+      case 'swift':
+        visitor = new AppSyncSwiftVisitor(schema, config, {
+          selectedType: config.selectedType,
+          generate: config.generate,
+        });
+        break;
+      case 'java':
+        visitor = new AppSyncModelJavaVisitor(schema, config, {
+          selectedType: config.selectedType,
+          generate: config.generate,
+        });
+        break;
+      case 'metadata':
+        visitor = new AppSyncJSONVisitor(schema, config, {});
+        break;
+      case 'typescript':
+        visitor = new AppSyncModelTypeScriptVisitor(schema, config, {});
+        break;
+      case 'javascript':
+        visitor = new AppSyncModelJavascriptVisitor(schema, config, {});
+        break;
+      case 'dart':
+        visitor = new AppSyncModelDartVisitor(schema, config, {
+          selectedType: config.selectedType,
+          generate: config.generate,
+        });
+        break;
+      case 'introspection':
+        visitor = new AppSyncModelIntrospectionVisitor(schema, config, {});
+        break;
+      default:
+        return '';
+    }
+    if (schema) {
+      const schemaStr = printSchemaWithDirectives(schema);
+      const node = parse(schemaStr);
+      visit(node, {
+        leave: visitor,
+      });
+      return visitor.generate();
+    }
+    return '';
+  }
+};

--- a/packages/appsync-modelgen-plugin/src/presetSync.ts
+++ b/packages/appsync-modelgen-plugin/src/presetSync.ts
@@ -1,0 +1,328 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { SyncTypes } from './syncTypes'
+import { Kind, TypeDefinitionNode } from 'graphql';
+import { join } from 'path';
+import { JAVA_SCALAR_MAP, SWIFT_SCALAR_MAP, TYPESCRIPT_SCALAR_MAP, DART_SCALAR_MAP, METADATA_SCALAR_MAP } from './scalars';
+import { LOADER_CLASS_NAME, GENERATED_PACKAGE_NAME } from './configs/java-config';
+import { graphqlName, toUpper } from 'graphql-transformer-common';
+import { AppSyncModelCodeGenPresetConfig } from './preset';
+
+const APPSYNC_DATA_STORE_CODEGEN_TARGETS = ['java', 'swift', 'javascript', 'typescript', 'dart', 'introspection'];
+
+const generateJavaPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+  manyToManyJoinModels: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir
+    ? [options.config.overrideOutputDir]
+    : [options.baseOutputDir, ...GENERATED_PACKAGE_NAME.split('.')];
+
+  // Only generate lazy models if feature flag enabled and datastore is not being used.
+  const generateAPILazyModels = options.config.generateModelsForLazyLoadAndCustomSelectionSet && !options.config.isDataStoreEnabled
+
+  // Class loader
+  config.push({
+    ...options,
+    filename: join(...modelFolder, `${LOADER_CLASS_NAME}.java`),
+    config: {
+      ...options.config,
+      scalars: { ...JAVA_SCALAR_MAP, ...options.config.scalars },
+      generate: 'loader',
+    },
+  });
+
+  models.forEach(model => {
+    const modelName = model.name.value;
+    config.push({
+      ...options,
+      filename: join(...modelFolder, `${modelName}.java`),
+      config: {
+        ...options.config,
+        scalars: { ...JAVA_SCALAR_MAP, ...options.config.scalars },
+        selectedType: modelName,
+      },
+    });
+
+    // Create ModelPath's only if lazy models are generated
+    if (generateAPILazyModels) {
+      // Create ModelPath if type is @model
+      if (model?.directives?.find((directive) => directive?.name?.value === 'model')) {
+        config.push({
+          ...options,
+          filename: join(...modelFolder, `${modelName}Path.java`),
+          config: {
+            ...options.config,
+            scalars: { ...JAVA_SCALAR_MAP, ...options.config.scalars },
+            generate: 'metadata',
+            selectedType: modelName,
+          },
+        });
+      }
+    }
+  });
+
+  // Create ModelPath's only if lazy models are generated
+  if (generateAPILazyModels) {
+    manyToManyJoinModels.forEach(joinModel => {
+      config.push({
+        ...options,
+        filename: join(...modelFolder, `${joinModel.name.value}Path.java`),
+        config: {
+          ...options.config,
+          scalars: {...JAVA_SCALAR_MAP, ...options.config.scalars},
+          generate: 'metadata',
+          selectedType: joinModel.name.value,
+        },
+      });
+    });
+  };
+
+  return config;
+};
+
+const generateSwiftPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : options.baseOutputDir;
+  models.forEach(model => {
+    const modelName = model.name.value;
+    config.push({
+      ...options,
+      filename: join(modelFolder, `${modelName}.swift`),
+      config: {
+        ...options.config,
+        scalars: { ...SWIFT_SCALAR_MAP, ...options.config.scalars },
+        generate: 'code',
+        selectedType: modelName,
+      },
+    });
+    if (model.kind !== Kind.ENUM_TYPE_DEFINITION) {
+      config.push({
+        ...options,
+        filename: join(modelFolder, `${modelName}+Schema.swift`),
+        config: {
+          ...options.config,
+          target: 'swift',
+          scalars: { ...SWIFT_SCALAR_MAP, ...options.config.scalars },
+          generate: 'metadata',
+          selectedType: modelName,
+        },
+      });
+    }
+  });
+
+  // class loader
+  config.push({
+    ...options,
+    filename: join(modelFolder, `AmplifyModels.swift`),
+    config: {
+      ...options.config,
+      scalars: { ...SWIFT_SCALAR_MAP, ...options.config.scalars },
+      target: 'swift',
+      generate: 'loader',
+    },
+  });
+  return config;
+};
+
+const generateTypeScriptPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : join(options.baseOutputDir);
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'index.ts'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      metadata: false,
+    },
+  });
+  // metadata
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'schema.ts'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      target: 'metadata',
+      metadataTarget: 'typescript',
+    },
+  });
+  return config;
+};
+
+const generateJavasScriptPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : join(options.baseOutputDir);
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'index.js'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      metadata: false,
+    },
+  });
+
+  //indx.d.ts
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'index.d.ts'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      metadata: false,
+      isDeclaration: true,
+    },
+  });
+  // metadata schema.js
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'schema.js'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      target: 'metadata',
+      metadataTarget: 'javascript',
+    },
+  });
+
+  // schema.d.ts
+  config.push({
+    ...options,
+    filename: join(modelFolder, 'schema.d.ts'),
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      target: 'metadata',
+      metadataTarget: 'typeDeclaration',
+    },
+  });
+  return config;
+};
+
+const generateDartPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ?? options.baseOutputDir;
+  models.forEach(model => {
+    const modelName = model.name.value;
+    config.push({
+      ...options,
+      filename: join(modelFolder, `${modelName}.dart`),
+      config: {
+        ...options.config,
+        scalars: { ...DART_SCALAR_MAP, ...options.config.scalars },
+        selectedType: modelName,
+      },
+    });
+  });
+  // Class loader
+  config.push({
+    ...options,
+    filename: join(modelFolder, `ModelProvider.dart`),
+    config: {
+      ...options.config,
+      scalars: { ...DART_SCALAR_MAP, ...options.config.scalars },
+      generate: 'loader',
+    },
+  });
+  return config;
+};
+
+const generateManyToManyModelStubs = (options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>): TypeDefinitionNode[] => {
+  let models = new Array<TypeDefinitionNode>();
+  let manyToManySet = new Set<string>();
+  options.schema.definitions.forEach(def => {
+    if (def.kind === 'ObjectTypeDefinition') {
+      def?.fields?.forEach(field => {
+        field?.directives?.forEach(dir => {
+          if (dir?.name?.value === 'manyToMany') {
+            dir?.arguments?.forEach(arg => {
+              if (arg.name.value === 'relationName' && arg.value.kind === 'StringValue') {
+                manyToManySet.add(graphqlName(toUpper(arg.value.value)));
+              }
+            });
+          }
+        });
+      });
+    }
+  });
+  manyToManySet.forEach(modelName => {
+    models.push({
+      kind: 'ObjectTypeDefinition',
+      name: {
+        kind: 'Name',
+        value: modelName,
+      },
+    });
+  });
+  return models;
+};
+
+const generateIntrospectionPreset = (
+  options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): SyncTypes.GenerateOptions[] => {
+  const config: SyncTypes.GenerateOptions[] = [];
+  // model-intropection.json
+  config.push({
+    ...options,
+    filename: join(options.config.overrideOutputDir!, 'model-introspection.json'),
+    config: {
+      ...options.config,
+      scalars: { ...METADATA_SCALAR_MAP, ...options.config.scalars },
+      target: 'introspection',
+    },
+  });
+  return config;
+};
+
+export const presetSync: SyncTypes.OutputPreset<AppSyncModelCodeGenPresetConfig> = {
+  buildGeneratesSection: (options: SyncTypes.PresetFnArgs<AppSyncModelCodeGenPresetConfig>): SyncTypes.GenerateOptions[] => {
+    const codeGenTarget = options.config.target;
+    const typesToSkip: string[] = ['Query', 'Mutation', 'Subscription'];
+    const models: TypeDefinitionNode[] = options.schema.definitions.filter(
+      t =>
+        (t.kind === 'ObjectTypeDefinition' && !typesToSkip.includes(t.name.value)) ||
+        (t.kind === 'EnumTypeDefinition' && !t.name.value.startsWith('__')),
+    ) as any;
+    const manyToManyModels = generateManyToManyModelStubs(options);
+    if (options.config.usePipelinedTransformer || options.config.transformerVersion === 2) {
+      models.push(...manyToManyModels);
+    }
+
+    switch (codeGenTarget) {
+      case 'java':
+        return generateJavaPreset(options, models, manyToManyModels);
+      case 'swift':
+        return generateSwiftPreset(options, models);
+      case 'javascript':
+        return generateJavasScriptPreset(options, models);
+      case 'typescript':
+        return generateTypeScriptPreset(options, models);
+      case 'dart':
+        return generateDartPreset(options, models);
+      case 'introspection':
+        return generateIntrospectionPreset(options, models);
+      default:
+        throw new Error(
+          `amplify-codegen-appsync-model-plugin not support language target ${codeGenTarget}. Supported codegen targets are ${APPSYNC_DATA_STORE_CODEGEN_TARGETS.join(
+            ', ',
+          )}`,
+        );
+    }
+  },
+};

--- a/packages/appsync-modelgen-plugin/src/syncTypes.ts
+++ b/packages/appsync-modelgen-plugin/src/syncTypes.ts
@@ -1,0 +1,34 @@
+import { Types, PluginFunction as PluginFunctionAsync, CodegenPlugin as CodegenPluginAsync } from "@graphql-codegen/plugin-helpers";
+
+type PluginMapContainer = Pick<Types.GenerateOptions, 'pluginMap'>
+
+type SyncPluginMap<Obj extends PluginMapContainer> = Omit<Obj, 'pluginMap'> & {
+    pluginMap: {
+        [name: string]: Omit<Obj['pluginMap'][string], 'plugin'> & {
+        plugin: (
+            ...args: Parameters<Obj['pluginMap'][string]['plugin']>
+        ) => Awaited<ReturnType<Obj['pluginMap'][string]['plugin']>>;
+        };
+    };
+};
+
+export declare namespace SyncTypes {
+    type GenerateOptions = SyncPluginMap<Types.GenerateOptions>;
+
+    type PresetFnArgs<
+        Config = any,
+        PluginConfig = {
+        [key: string]: any;
+        }
+    > = SyncPluginMap<Types.PresetFnArgs<Config, PluginConfig>>;
+
+    type OutputPreset<TPresetConfig = any> = {
+        buildGeneratesSection: (options: PresetFnArgs<TPresetConfig>) => GenerateOptions[];
+    };
+
+    type PluginFunction<T> = (...args: Parameters<PluginFunctionAsync<T>>) => Awaited<ReturnType<PluginFunctionAsync<T>>>;
+
+    type CodegenPlugin<T = any> = Omit<CodegenPluginAsync<T>, 'plugin'> & {
+        plugin: PluginFunction<T>;
+    }
+};

--- a/packages/graphql-generator/package.json
+++ b/packages/graphql-generator/package.json
@@ -61,6 +61,9 @@
         "lines": 90
       }
     },
+    "coveragePathIgnorePatterns": [
+      "codegenSync"
+    ],
     "coverageReporters": [
       "clover",
       "text"

--- a/packages/graphql-generator/src/__tests__/__snapshots__/modelsSync.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/__snapshots__/modelsSync.test.ts.snap
@@ -1,0 +1,3295 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateModelsSync does not fail on custom directives 1`] = `
+Object {
+  "model-introspection.json": "{
+    \\"version\\": 1,
+    \\"models\\": {},
+    \\"enums\\": {},
+    \\"nonModels\\": {
+        \\"Blog\\": {
+            \\"name\\": \\"Blog\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                }
+            }
+        }
+    }
+}",
+}
+`;
+
+exports[`generateModelsSync targets basic dart 1`] = `
+Object {
+  "Blog.dart": "/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
+
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
+import 'package:collection/collection.dart';
+
+
+/** This is an auto generated class representing the Blog type in your schema. */
+class Blog extends amplify_core.Model {
+  static const classType = const _BlogModelType();
+  final String id;
+  final String? _name;
+  final List<Post>? _posts;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
+
+  @override
+  getInstanceType() => classType;
+  
+  @Deprecated('[getId] is being deprecated in favor of custom primary key feature. Use getter [modelIdentifier] to get model identifier.')
+  @override
+  String getId() => id;
+  
+  BlogModelIdentifier get modelIdentifier {
+      return BlogModelIdentifier(
+        id: id
+      );
+  }
+  
+  String get name {
+    try {
+      return _name!;
+    } catch(e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  List<Post>? get posts {
+    return _posts;
+  }
+  
+  amplify_core.TemporalDateTime? get createdAt {
+    return _createdAt;
+  }
+  
+  amplify_core.TemporalDateTime? get updatedAt {
+    return _updatedAt;
+  }
+  
+  const Blog._internal({required this.id, required name, posts, createdAt, updatedAt}): _name = name, _posts = posts, _createdAt = createdAt, _updatedAt = updatedAt;
+  
+  factory Blog({String? id, required String name, List<Post>? posts}) {
+    return Blog._internal(
+      id: id == null ? amplify_core.UUID.getUUID() : id,
+      name: name,
+      posts: posts != null ? List<Post>.unmodifiable(posts) : posts);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Blog &&
+      id == other.id &&
+      _name == other._name &&
+      DeepCollectionEquality().equals(_posts, other._posts);
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Blog {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"name=\\" + \\"$_name\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Blog copyWith({String? name, List<Post>? posts}) {
+    return Blog._internal(
+      id: id,
+      name: name ?? this.name,
+      posts: posts ?? this.posts);
+  }
+  
+  Blog copyWithModelFieldValues({
+    ModelFieldValue<String>? name,
+    ModelFieldValue<List<Post>?>? posts
+  }) {
+    return Blog._internal(
+      id: id,
+      name: name == null ? this.name : name.value,
+      posts: posts == null ? this.posts : posts.value
+    );
+  }
+  
+  Blog.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _name = json['name'],
+      _posts = json['posts']  is Map
+        ? (json['posts']['items'] is List
+          ? (json['posts']['items'] as List)
+              .where((e) => e != null)
+              .map((e) => Post.fromJson(new Map<String, dynamic>.from(e)))
+              .toList()
+          : null)
+        : (json['posts'] is List
+          ? (json['posts'] as List)
+              .where((e) => e?['serializedData'] != null)
+              .map((e) => Post.fromJson(new Map<String, dynamic>.from(e?['serializedData'])))
+              .toList()
+          : null),
+      _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'name': _name, 'posts': _posts?.map((Post? e) => e?.toJson()).toList(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+  };
+  
+  Map<String, Object?> toMap() => {
+    'id': id,
+    'name': _name,
+    'posts': _posts,
+    'createdAt': _createdAt,
+    'updatedAt': _updatedAt
+  };
+
+  static final amplify_core.QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<BlogModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: \\"id\\");
+  static final NAME = amplify_core.QueryField(fieldName: \\"name\\");
+  static final POSTS = amplify_core.QueryField(
+    fieldName: \\"posts\\",
+    fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Post'));
+  static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Blog\\";
+    modelSchemaDefinition.pluralName = \\"Blogs\\";
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
+      key: Blog.NAME,
+      isRequired: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasMany(
+      key: Blog.POSTS,
+      isRequired: false,
+      ofModelName: 'Post',
+      associatedKey: Post.BLOG
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'createdAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'updatedAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+  });
+}
+
+class _BlogModelType extends amplify_core.ModelType<Blog> {
+  const _BlogModelType();
+  
+  @override
+  Blog fromJson(Map<String, dynamic> jsonData) {
+    return Blog.fromJson(jsonData);
+  }
+  
+  @override
+  String modelName() {
+    return 'Blog';
+  }
+}
+
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Blog] in your schema.
+ */
+class BlogModelIdentifier implements amplify_core.ModelIdentifier<Blog> {
+  final String id;
+
+  /** Create an instance of BlogModelIdentifier using [id] the primary key. */
+  const BlogModelIdentifier({
+    required this.id});
+  
+  @override
+  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
+    'id': id
+  });
+  
+  @override
+  List<Map<String, dynamic>> serializeAsList() => serializeAsMap()
+    .entries
+    .map((entry) => (<String, dynamic>{ entry.key: entry.value }))
+    .toList();
+  
+  @override
+  String serializeAsString() => serializeAsMap().values.join('#');
+  
+  @override
+  String toString() => 'BlogModelIdentifier(id: $id)';
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    
+    return other is BlogModelIdentifier &&
+      id == other.id;
+  }
+  
+  @override
+  int get hashCode =>
+    id.hashCode;
+}",
+  "Comment.dart": "/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
+
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
+
+
+/** This is an auto generated class representing the Comment type in your schema. */
+class Comment extends amplify_core.Model {
+  static const classType = const _CommentModelType();
+  final String id;
+  final Post? _post;
+  final String? _content;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
+
+  @override
+  getInstanceType() => classType;
+  
+  @Deprecated('[getId] is being deprecated in favor of custom primary key feature. Use getter [modelIdentifier] to get model identifier.')
+  @override
+  String getId() => id;
+  
+  CommentModelIdentifier get modelIdentifier {
+      return CommentModelIdentifier(
+        id: id
+      );
+  }
+  
+  Post? get post {
+    return _post;
+  }
+  
+  String get content {
+    try {
+      return _content!;
+    } catch(e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  amplify_core.TemporalDateTime? get createdAt {
+    return _createdAt;
+  }
+  
+  amplify_core.TemporalDateTime? get updatedAt {
+    return _updatedAt;
+  }
+  
+  const Comment._internal({required this.id, post, required content, createdAt, updatedAt}): _post = post, _content = content, _createdAt = createdAt, _updatedAt = updatedAt;
+  
+  factory Comment({String? id, Post? post, required String content}) {
+    return Comment._internal(
+      id: id == null ? amplify_core.UUID.getUUID() : id,
+      post: post,
+      content: content);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Comment &&
+      id == other.id &&
+      _post == other._post &&
+      _content == other._content;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Comment {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"post=\\" + (_post != null ? _post!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Comment copyWith({Post? post, String? content}) {
+    return Comment._internal(
+      id: id,
+      post: post ?? this.post,
+      content: content ?? this.content);
+  }
+  
+  Comment copyWithModelFieldValues({
+    ModelFieldValue<Post?>? post,
+    ModelFieldValue<String>? content
+  }) {
+    return Comment._internal(
+      id: id,
+      post: post == null ? this.post : post.value,
+      content: content == null ? this.content : content.value
+    );
+  }
+  
+  Comment.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _post = json['post'] != null
+        ? json['post']['serializedData'] != null
+          ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+          : Post.fromJson(new Map<String, dynamic>.from(json['post']))
+        : null,
+      _content = json['content'],
+      _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'post': _post?.toJson(), 'content': _content, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+  };
+  
+  Map<String, Object?> toMap() => {
+    'id': id,
+    'post': _post,
+    'content': _content,
+    'createdAt': _createdAt,
+    'updatedAt': _updatedAt
+  };
+
+  static final amplify_core.QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<CommentModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: \\"id\\");
+  static final POST = amplify_core.QueryField(
+    fieldName: \\"post\\",
+    fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Post'));
+  static final CONTENT = amplify_core.QueryField(fieldName: \\"content\\");
+  static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Comment\\";
+    modelSchemaDefinition.pluralName = \\"Comments\\";
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
+      key: Comment.POST,
+      isRequired: false,
+      targetNames: ['postCommentsId'],
+      ofModelName: 'Post'
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
+      key: Comment.CONTENT,
+      isRequired: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'createdAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'updatedAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+  });
+}
+
+class _CommentModelType extends amplify_core.ModelType<Comment> {
+  const _CommentModelType();
+  
+  @override
+  Comment fromJson(Map<String, dynamic> jsonData) {
+    return Comment.fromJson(jsonData);
+  }
+  
+  @override
+  String modelName() {
+    return 'Comment';
+  }
+}
+
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Comment] in your schema.
+ */
+class CommentModelIdentifier implements amplify_core.ModelIdentifier<Comment> {
+  final String id;
+
+  /** Create an instance of CommentModelIdentifier using [id] the primary key. */
+  const CommentModelIdentifier({
+    required this.id});
+  
+  @override
+  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
+    'id': id
+  });
+  
+  @override
+  List<Map<String, dynamic>> serializeAsList() => serializeAsMap()
+    .entries
+    .map((entry) => (<String, dynamic>{ entry.key: entry.value }))
+    .toList();
+  
+  @override
+  String serializeAsString() => serializeAsMap().values.join('#');
+  
+  @override
+  String toString() => 'CommentModelIdentifier(id: $id)';
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    
+    return other is CommentModelIdentifier &&
+      id == other.id;
+  }
+  
+  @override
+  int get hashCode =>
+    id.hashCode;
+}",
+  "ModelProvider.dart": "/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
+
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
+import 'Blog.dart';
+import 'Comment.dart';
+import 'Post.dart';
+
+export 'Blog.dart';
+export 'Comment.dart';
+export 'Post.dart';
+
+class ModelProvider implements amplify_core.ModelProviderInterface {
+  @override
+  String version = \\"165944a36979cd395e3b22145bbfeff0\\";
+  @override
+  List<amplify_core.ModelSchema> modelSchemas = [Blog.schema, Comment.schema, Post.schema];
+  @override
+  List<amplify_core.ModelSchema> customTypeSchemas = [];
+  static final ModelProvider _instance = ModelProvider();
+
+  static ModelProvider get instance => _instance;
+  
+  amplify_core.ModelType getModelTypeByModelName(String modelName) {
+    switch(modelName) {
+      case \\"Blog\\":
+        return Blog.classType;
+      case \\"Comment\\":
+        return Comment.classType;
+      case \\"Post\\":
+        return Post.classType;
+      default:
+        throw Exception(\\"Failed to find model in model provider for model name: \\" + modelName);
+    }
+  }
+}
+
+
+class ModelFieldValue<T> {
+  const ModelFieldValue.value(this.value);
+
+  final T value;
+}
+",
+  "Post.dart": "/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, override_on_non_overriding_member, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously
+
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core.dart' as amplify_core;
+import 'package:collection/collection.dart';
+
+
+/** This is an auto generated class representing the Post type in your schema. */
+class Post extends amplify_core.Model {
+  static const classType = const _PostModelType();
+  final String id;
+  final String? _title;
+  final Blog? _blog;
+  final List<Comment>? _comments;
+  final amplify_core.TemporalDateTime? _createdAt;
+  final amplify_core.TemporalDateTime? _updatedAt;
+
+  @override
+  getInstanceType() => classType;
+  
+  @Deprecated('[getId] is being deprecated in favor of custom primary key feature. Use getter [modelIdentifier] to get model identifier.')
+  @override
+  String getId() => id;
+  
+  PostModelIdentifier get modelIdentifier {
+      return PostModelIdentifier(
+        id: id
+      );
+  }
+  
+  String get title {
+    try {
+      return _title!;
+    } catch(e) {
+      throw amplify_core.AmplifyCodeGenModelException(
+          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  Blog? get blog {
+    return _blog;
+  }
+  
+  List<Comment>? get comments {
+    return _comments;
+  }
+  
+  amplify_core.TemporalDateTime? get createdAt {
+    return _createdAt;
+  }
+  
+  amplify_core.TemporalDateTime? get updatedAt {
+    return _updatedAt;
+  }
+  
+  const Post._internal({required this.id, required title, blog, comments, createdAt, updatedAt}): _title = title, _blog = blog, _comments = comments, _createdAt = createdAt, _updatedAt = updatedAt;
+  
+  factory Post({String? id, required String title, Blog? blog, List<Comment>? comments}) {
+    return Post._internal(
+      id: id == null ? amplify_core.UUID.getUUID() : id,
+      title: title,
+      blog: blog,
+      comments: comments != null ? List<Comment>.unmodifiable(comments) : comments);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Post &&
+      id == other.id &&
+      _title == other._title &&
+      _blog == other._blog &&
+      DeepCollectionEquality().equals(_comments, other._comments);
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Post {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"title=\\" + \\"$_title\\" + \\", \\");
+    buffer.write(\\"blog=\\" + (_blog != null ? _blog!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Post copyWith({String? title, Blog? blog, List<Comment>? comments}) {
+    return Post._internal(
+      id: id,
+      title: title ?? this.title,
+      blog: blog ?? this.blog,
+      comments: comments ?? this.comments);
+  }
+  
+  Post copyWithModelFieldValues({
+    ModelFieldValue<String>? title,
+    ModelFieldValue<Blog?>? blog,
+    ModelFieldValue<List<Comment>?>? comments
+  }) {
+    return Post._internal(
+      id: id,
+      title: title == null ? this.title : title.value,
+      blog: blog == null ? this.blog : blog.value,
+      comments: comments == null ? this.comments : comments.value
+    );
+  }
+  
+  Post.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _title = json['title'],
+      _blog = json['blog'] != null
+        ? json['blog']['serializedData'] != null
+          ? Blog.fromJson(new Map<String, dynamic>.from(json['blog']['serializedData']))
+          : Blog.fromJson(new Map<String, dynamic>.from(json['blog']))
+        : null,
+      _comments = json['comments']  is Map
+        ? (json['comments']['items'] is List
+          ? (json['comments']['items'] as List)
+              .where((e) => e != null)
+              .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e)))
+              .toList()
+          : null)
+        : (json['comments'] is List
+          ? (json['comments'] as List)
+              .where((e) => e?['serializedData'] != null)
+              .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e?['serializedData'])))
+              .toList()
+          : null),
+      _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+  };
+  
+  Map<String, Object?> toMap() => {
+    'id': id,
+    'title': _title,
+    'blog': _blog,
+    'comments': _comments,
+    'createdAt': _createdAt,
+    'updatedAt': _updatedAt
+  };
+
+  static final amplify_core.QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<PostModelIdentifier>();
+  static final ID = amplify_core.QueryField(fieldName: \\"id\\");
+  static final TITLE = amplify_core.QueryField(fieldName: \\"title\\");
+  static final BLOG = amplify_core.QueryField(
+    fieldName: \\"blog\\",
+    fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Blog'));
+  static final COMMENTS = amplify_core.QueryField(
+    fieldName: \\"comments\\",
+    fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Comment'));
+  static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Post\\";
+    modelSchemaDefinition.pluralName = \\"Posts\\";
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
+      key: Post.TITLE,
+      isRequired: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
+      key: Post.BLOG,
+      isRequired: false,
+      targetNames: ['blogPostsId'],
+      ofModelName: 'Blog'
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasMany(
+      key: Post.COMMENTS,
+      isRequired: false,
+      ofModelName: 'Comment',
+      associatedKey: Comment.POST
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'createdAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+    
+    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
+      fieldName: 'updatedAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
+    ));
+  });
+}
+
+class _PostModelType extends amplify_core.ModelType<Post> {
+  const _PostModelType();
+  
+  @override
+  Post fromJson(Map<String, dynamic> jsonData) {
+    return Post.fromJson(jsonData);
+  }
+  
+  @override
+  String modelName() {
+    return 'Post';
+  }
+}
+
+/**
+ * This is an auto generated class representing the model identifier
+ * of [Post] in your schema.
+ */
+class PostModelIdentifier implements amplify_core.ModelIdentifier<Post> {
+  final String id;
+
+  /** Create an instance of PostModelIdentifier using [id] the primary key. */
+  const PostModelIdentifier({
+    required this.id});
+  
+  @override
+  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
+    'id': id
+  });
+  
+  @override
+  List<Map<String, dynamic>> serializeAsList() => serializeAsMap()
+    .entries
+    .map((entry) => (<String, dynamic>{ entry.key: entry.value }))
+    .toList();
+  
+  @override
+  String serializeAsString() => serializeAsMap().values.join('#');
+  
+  @override
+  String toString() => 'PostModelIdentifier(id: $id)';
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    
+    return other is PostModelIdentifier &&
+      id == other.id;
+  }
+  
+  @override
+  int get hashCode =>
+    id.hashCode;
+}",
+}
+`;
+
+exports[`generateModelsSync targets basic introspection 1`] = `
+Object {
+  "model-introspection.json": "{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"Blog\\": {
+            \\"name\\": \\"Blog\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"posts\\": {
+                    \\"name\\": \\"posts\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Blogs\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"blog\\": {
+                    \\"name\\": \\"blog\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Blog\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"blogPostsId\\": {
+                    \\"name\\": \\"blogPostsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}",
+}
+`;
+
+exports[`generateModelsSync targets basic java 1`] = `
+Object {
+  "com/amplifyframework/datastore/generated/model/AmplifyModelProvider.java": "package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.util.Immutable;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelProvider;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+/**
+ *  Contains the set of model classes that implement {@link Model}
+ * interface.
+ */
+
+public final class AmplifyModelProvider implements ModelProvider {
+  private static final String AMPLIFY_MODEL_VERSION = \\"165944a36979cd395e3b22145bbfeff0\\";
+  private static AmplifyModelProvider amplifyGeneratedModelInstance;
+  private AmplifyModelProvider() {
+    
+  }
+  
+  public static synchronized AmplifyModelProvider getInstance() {
+    if (amplifyGeneratedModelInstance == null) {
+      amplifyGeneratedModelInstance = new AmplifyModelProvider();
+    }
+    return amplifyGeneratedModelInstance;
+  }
+  
+  /**
+   * Get a set of the model classes.
+   *
+   * @return a set of the model classes.
+   */
+  @Override
+   public Set<Class<? extends Model>> models() {
+    final Set<Class<? extends Model>> modifiableSet = new HashSet<>(
+          Arrays.<Class<? extends Model>>asList(Blog.class, Post.class, Comment.class)
+        );
+    
+        return Immutable.of(modifiableSet);
+        
+  }
+  
+  /**
+   * Get the version of the models.
+   *
+   * @return the version string of the models.
+   */
+  @Override
+   public String version() {
+    return AMPLIFY_MODEL_VERSION;
+  }
+}
+",
+  "com/amplifyframework/datastore/generated/model/Blog.java": "package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.ModelList;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.ModelIdentifier;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Blog type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"Blogs\\", type = Model.Type.USER, version = 1, hasLazySupport = true)
+public final class Blog implements Model {
+  public static final BlogPath rootPath = new BlogPath(\\"root\\", false, null);
+  public static final QueryField ID = field(\\"Blog\\", \\"id\\");
+  public static final QueryField NAME = field(\\"Blog\\", \\"name\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
+  private final @ModelField(targetType=\\"Post\\") @HasMany(associatedWith = \\"blog\\", type = Post.class) ModelList<Post> posts = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
+    return id;
+  }
+  
+  public String getId() {
+      return id;
+  }
+  
+  public String getName() {
+      return name;
+  }
+  
+  public ModelList<Post> getPosts() {
+      return posts;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Blog(String id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Blog blog = (Blog) obj;
+      return ObjectsCompat.equals(getId(), blog.getId()) &&
+              ObjectsCompat.equals(getName(), blog.getName()) &&
+              ObjectsCompat.equals(getCreatedAt(), blog.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), blog.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getName())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"Blog {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  /**
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static Blog justId(String id) {
+    return new Blog(
+      id,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      name);
+  }
+  public interface NameStep {
+    BuildStep name(String name);
+  }
+  
+
+  public interface BuildStep {
+    Blog build();
+    BuildStep id(String id);
+  }
+  
+
+  public static class Builder implements NameStep, BuildStep {
+    private String id;
+    private String name;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+    
+    @Override
+     public Blog build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Blog(
+          id,
+          name);
+    }
+    
+    @Override
+     public BuildStep name(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        return this;
+    }
+    
+    /**
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String name) {
+      super(id, name);
+      Objects.requireNonNull(name);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+  }
+  
+
+  public static class BlogIdentifier extends ModelIdentifier<Blog> {
+    private static final long serialVersionUID = 1L;
+    public BlogIdentifier(String id) {
+      super(id);
+    }
+  }
+  
+}
+",
+  "com/amplifyframework/datastore/generated/model/BlogPath.java": "package com.amplifyframework.datastore.generated.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.model.ModelPath;
+import com.amplifyframework.core.model.PropertyPath;
+
+/** This is an auto generated class representing the ModelPath for the Blog type in your schema. */
+public final class BlogPath extends ModelPath<Blog> {
+  private PostPath posts;
+  BlogPath(@NonNull String name, @NonNull Boolean isCollection, @Nullable PropertyPath parent) {
+    super(name, isCollection, parent, Blog.class);
+  }
+  
+  public synchronized PostPath getPosts() {
+    if (posts == null) {
+      posts = new PostPath(\\"posts\\", true, this);
+    }
+    return posts;
+  }
+}
+",
+  "com/amplifyframework/datastore/generated/model/Comment.java": "package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelReference;
+import com.amplifyframework.core.model.LoadedModelReferenceImpl;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.ModelIdentifier;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Comment type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"Comments\\", type = Model.Type.USER, version = 1, hasLazySupport = true)
+public final class Comment implements Model {
+  public static final CommentPath rootPath = new CommentPath(\\"root\\", false, null);
+  public static final QueryField ID = field(\\"Comment\\", \\"id\\");
+  public static final QueryField POST = field(\\"Comment\\", \\"postCommentsId\\");
+  public static final QueryField CONTENT = field(\\"Comment\\", \\"content\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"Post\\") @BelongsTo(targetName = \\"postCommentsId\\", targetNames = {\\"postCommentsId\\"}, type = Post.class) ModelReference<Post> post;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String content;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
+    return id;
+  }
+  
+  public String getId() {
+      return id;
+  }
+  
+  public ModelReference<Post> getPost() {
+      return post;
+  }
+  
+  public String getContent() {
+      return content;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Comment(String id, ModelReference<Post> post, String content) {
+    this.id = id;
+    this.post = post;
+    this.content = content;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Comment comment = (Comment) obj;
+      return ObjectsCompat.equals(getId(), comment.getId()) &&
+              ObjectsCompat.equals(getPost(), comment.getPost()) &&
+              ObjectsCompat.equals(getContent(), comment.getContent()) &&
+              ObjectsCompat.equals(getCreatedAt(), comment.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), comment.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getPost())
+      .append(getContent())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"Comment {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"post=\\" + String.valueOf(getPost()) + \\", \\")
+      .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static ContentStep builder() {
+      return new Builder();
+  }
+  
+  /**
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static Comment justId(String id) {
+    return new Comment(
+      id,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      post,
+      content);
+  }
+  public interface ContentStep {
+    BuildStep content(String content);
+  }
+  
+
+  public interface BuildStep {
+    Comment build();
+    BuildStep id(String id);
+    BuildStep post(Post post);
+  }
+  
+
+  public static class Builder implements ContentStep, BuildStep {
+    private String id;
+    private String content;
+    private ModelReference<Post> post;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, ModelReference<Post> post, String content) {
+      this.id = id;
+      this.post = post;
+      this.content = content;
+    }
+    
+    @Override
+     public Comment build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Comment(
+          id,
+          post,
+          content);
+    }
+    
+    @Override
+     public BuildStep content(String content) {
+        Objects.requireNonNull(content);
+        this.content = content;
+        return this;
+    }
+    
+    @Override
+     public BuildStep post(Post post) {
+        this.post = new LoadedModelReferenceImpl<>(post);
+        return this;
+    }
+    
+    /**
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, ModelReference<Post> post, String content) {
+      super(id, post, content);
+      Objects.requireNonNull(content);
+    }
+    
+    @Override
+     public CopyOfBuilder content(String content) {
+      return (CopyOfBuilder) super.content(content);
+    }
+    
+    @Override
+     public CopyOfBuilder post(Post post) {
+      return (CopyOfBuilder) super.post(post);
+    }
+  }
+  
+
+  public static class CommentIdentifier extends ModelIdentifier<Comment> {
+    private static final long serialVersionUID = 1L;
+    public CommentIdentifier(String id) {
+      super(id);
+    }
+  }
+  
+}
+",
+  "com/amplifyframework/datastore/generated/model/CommentPath.java": "package com.amplifyframework.datastore.generated.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.model.ModelPath;
+import com.amplifyframework.core.model.PropertyPath;
+
+/** This is an auto generated class representing the ModelPath for the Comment type in your schema. */
+public final class CommentPath extends ModelPath<Comment> {
+  private PostPath post;
+  CommentPath(@NonNull String name, @NonNull Boolean isCollection, @Nullable PropertyPath parent) {
+    super(name, isCollection, parent, Comment.class);
+  }
+  
+  public synchronized PostPath getPost() {
+    if (post == null) {
+      post = new PostPath(\\"post\\", false, this);
+    }
+    return post;
+  }
+}
+",
+  "com/amplifyframework/datastore/generated/model/Post.java": "package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.annotations.BelongsTo;
+import com.amplifyframework.core.model.ModelReference;
+import com.amplifyframework.core.model.LoadedModelReferenceImpl;
+import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.ModelList;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.ModelIdentifier;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Post type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"Posts\\", type = Model.Type.USER, version = 1, hasLazySupport = true)
+public final class Post implements Model {
+  public static final PostPath rootPath = new PostPath(\\"root\\", false, null);
+  public static final QueryField ID = field(\\"Post\\", \\"id\\");
+  public static final QueryField TITLE = field(\\"Post\\", \\"title\\");
+  public static final QueryField BLOG = field(\\"Post\\", \\"blogPostsId\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
+  private final @ModelField(targetType=\\"Blog\\") @BelongsTo(targetName = \\"blogPostsId\\", targetNames = {\\"blogPostsId\\"}, type = Blog.class) ModelReference<Blog> blog;
+  private final @ModelField(targetType=\\"Comment\\") @HasMany(associatedWith = \\"post\\", type = Comment.class) ModelList<Comment> comments = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  /** @deprecated This API is internal to Amplify and should not be used. */
+  @Deprecated
+   public String resolveIdentifier() {
+    return id;
+  }
+  
+  public String getId() {
+      return id;
+  }
+  
+  public String getTitle() {
+      return title;
+  }
+  
+  public ModelReference<Blog> getBlog() {
+      return blog;
+  }
+  
+  public ModelList<Comment> getComments() {
+      return comments;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Post(String id, String title, ModelReference<Blog> blog) {
+    this.id = id;
+    this.title = title;
+    this.blog = blog;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Post post = (Post) obj;
+      return ObjectsCompat.equals(getId(), post.getId()) &&
+              ObjectsCompat.equals(getTitle(), post.getTitle()) &&
+              ObjectsCompat.equals(getBlog(), post.getBlog()) &&
+              ObjectsCompat.equals(getCreatedAt(), post.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), post.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getTitle())
+      .append(getBlog())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"Post {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"title=\\" + String.valueOf(getTitle()) + \\", \\")
+      .append(\\"blog=\\" + String.valueOf(getBlog()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static TitleStep builder() {
+      return new Builder();
+  }
+  
+  /**
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static Post justId(String id) {
+    return new Post(
+      id,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      title,
+      blog);
+  }
+  public interface TitleStep {
+    BuildStep title(String title);
+  }
+  
+
+  public interface BuildStep {
+    Post build();
+    BuildStep id(String id);
+    BuildStep blog(Blog blog);
+  }
+  
+
+  public static class Builder implements TitleStep, BuildStep {
+    private String id;
+    private String title;
+    private ModelReference<Blog> blog;
+    public Builder() {
+      
+    }
+    
+    private Builder(String id, String title, ModelReference<Blog> blog) {
+      this.id = id;
+      this.title = title;
+      this.blog = blog;
+    }
+    
+    @Override
+     public Post build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Post(
+          id,
+          title,
+          blog);
+    }
+    
+    @Override
+     public BuildStep title(String title) {
+        Objects.requireNonNull(title);
+        this.title = title;
+        return this;
+    }
+    
+    @Override
+     public BuildStep blog(Blog blog) {
+        this.blog = new LoadedModelReferenceImpl<>(blog);
+        return this;
+    }
+    
+    /**
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String title, ModelReference<Blog> blog) {
+      super(id, title, blog);
+      Objects.requireNonNull(title);
+    }
+    
+    @Override
+     public CopyOfBuilder title(String title) {
+      return (CopyOfBuilder) super.title(title);
+    }
+    
+    @Override
+     public CopyOfBuilder blog(Blog blog) {
+      return (CopyOfBuilder) super.blog(blog);
+    }
+  }
+  
+
+  public static class PostIdentifier extends ModelIdentifier<Post> {
+    private static final long serialVersionUID = 1L;
+    public PostIdentifier(String id) {
+      super(id);
+    }
+  }
+  
+}
+",
+  "com/amplifyframework/datastore/generated/model/PostPath.java": "package com.amplifyframework.datastore.generated.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.amplifyframework.core.model.ModelPath;
+import com.amplifyframework.core.model.PropertyPath;
+
+/** This is an auto generated class representing the ModelPath for the Post type in your schema. */
+public final class PostPath extends ModelPath<Post> {
+  private BlogPath blog;
+  private CommentPath comments;
+  PostPath(@NonNull String name, @NonNull Boolean isCollection, @Nullable PropertyPath parent) {
+    super(name, isCollection, parent, Post.class);
+  }
+  
+  public synchronized BlogPath getBlog() {
+    if (blog == null) {
+      blog = new BlogPath(\\"blog\\", false, this);
+    }
+    return blog;
+  }
+  
+  public synchronized CommentPath getComments() {
+    if (comments == null) {
+      comments = new CommentPath(\\"comments\\", true, this);
+    }
+    return comments;
+  }
+}
+",
+}
+`;
+
+exports[`generateModelsSync targets basic javascript 1`] = `
+Object {
+  "index.d.ts": "import { ModelInit, MutableModel, __modelMeta__, ManagedIdentifier } from \\"@aws-amplify/datastore\\";
+// @ts-ignore
+import { LazyLoading, LazyLoadingDisabled, AsyncCollection, AsyncItem } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+type EagerBlog = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Blog, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly posts?: (Post | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+type LazyBlog = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Blog, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly posts: AsyncCollection<Post>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+export declare type Blog = LazyLoading extends LazyLoadingDisabled ? EagerBlog : LazyBlog
+
+export declare const Blog: (new (init: ModelInit<Blog>) => Blog) & {
+  copyOf(source: Blog, mutator: (draft: MutableModel<Blog>) => MutableModel<Blog> | void): Blog;
+}
+
+type EagerPost = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Post, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly blog?: Blog | null;
+  readonly comments?: (Comment | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly blogPostsId?: string | null;
+}
+
+type LazyPost = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Post, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly blog: AsyncItem<Blog | undefined>;
+  readonly comments: AsyncCollection<Comment>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly blogPostsId?: string | null;
+}
+
+export declare type Post = LazyLoading extends LazyLoadingDisabled ? EagerPost : LazyPost
+
+export declare const Post: (new (init: ModelInit<Post>) => Post) & {
+  copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+}
+
+type EagerComment = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Comment, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly post?: Post | null;
+  readonly content: string;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly postCommentsId?: string | null;
+}
+
+type LazyComment = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Comment, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly post: AsyncItem<Post | undefined>;
+  readonly content: string;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly postCommentsId?: string | null;
+}
+
+export declare type Comment = LazyLoading extends LazyLoadingDisabled ? EagerComment : LazyComment
+
+export declare const Comment: (new (init: ModelInit<Comment>) => Comment) & {
+  copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+}",
+  "index.js": "// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+
+
+const { Blog, Post, Comment } = initSchema(schema);
+
+export {
+  Blog,
+  Post,
+  Comment
+};",
+  "schema.d.ts": "import { Schema } from '@aws-amplify/datastore';
+
+export declare const schema: Schema;",
+  "schema.js": "export const schema = {
+    \\"models\\": {
+        \\"Blog\\": {
+            \\"name\\": \\"Blog\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"posts\\": {
+                    \\"name\\": \\"posts\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Blogs\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"blog\\": {
+                    \\"name\\": \\"blog\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Blog\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"blogPostsId\\": {
+                    \\"name\\": \\"blogPostsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"920118e6cbedacf9fdf58bb983d59a94\\"
+};",
+}
+`;
+
+exports[`generateModelsSync targets basic swift 1`] = `
+Object {
+  "AmplifyModels.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+// Contains the set of classes that conforms to the \`Model\` protocol. 
+
+final public class AmplifyModels: AmplifyModelRegistration {
+  public let version: String = \\"165944a36979cd395e3b22145bbfeff0\\"
+  
+  public func registerModels(registry: ModelRegistry.Type) {
+    ModelRegistry.register(modelType: Blog.self)
+    ModelRegistry.register(modelType: Post.self)
+    ModelRegistry.register(modelType: Comment.self)
+  }
+}",
+  "Blog+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Blog {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case posts
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let blog = Blog.keys
+    
+    model.listPluralName = \\"Blogs\\"
+    model.syncPluralName = \\"Blogs\\"
+    
+    model.attributes(
+      .primaryKey(fields: [blog.id])
+    )
+    
+    model.fields(
+      .field(blog.id, is: .required, ofType: .string),
+      .field(blog.name, is: .required, ofType: .string),
+      .hasMany(blog.posts, is: .optional, ofType: Post.self, associatedWith: Post.keys.blog),
+      .field(blog.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(blog.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Blog> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Blog: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Blog {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var name: FieldPath<String>   {
+      string(\\"name\\") 
+    }
+  public var posts: ModelPath<Post>   {
+      Post.Path(name: \\"posts\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Blog.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Blog: Model {
+  public let id: String
+  public var name: String
+  public var posts: List<Post>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      name: String,
+      posts: List<Post>? = []) {
+    self.init(id: id,
+      name: name,
+      posts: posts,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      name: String,
+      posts: List<Post>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.name = name
+      self.posts = posts
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}",
+  "Comment+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case post
+    case content
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment = Comment.keys
+    
+    model.listPluralName = \\"Comments\\"
+    model.syncPluralName = \\"Comments\\"
+    
+    model.attributes(
+      .primaryKey(fields: [comment.id])
+    )
+    
+    model.fields(
+      .field(comment.id, is: .required, ofType: .string),
+      .belongsTo(comment.post, is: .optional, ofType: Post.self, targetNames: [\\"postCommentsId\\"]),
+      .field(comment.content, is: .required, ofType: .string),
+      .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var post: ModelPath<Post>   {
+      Post.Path(name: \\"post\\", parent: self) 
+    }
+  public var content: FieldPath<String>   {
+      string(\\"content\\") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Comment.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment: Model {
+  public let id: String
+  internal var _post: LazyReference<Post>
+  public var post: Post?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  public var content: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      post: Post? = nil,
+      content: String) {
+    self.init(id: id,
+      post: post,
+      content: content,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      post: Post? = nil,
+      content: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self._post = LazyReference(post)
+      self.content = content
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post? = nil) {
+    self._post = LazyReference(post)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      _post = try values.decodeIfPresent(LazyReference<Post>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      content = try values.decode(String.self, forKey: .content)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(_post, forKey: .post)
+      try container.encode(content, forKey: .content)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}",
+  "Post+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case blog
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post = Post.keys
+    
+    model.listPluralName = \\"Posts\\"
+    model.syncPluralName = \\"Posts\\"
+    
+    model.attributes(
+      .primaryKey(fields: [post.id])
+    )
+    
+    model.fields(
+      .field(post.id, is: .required, ofType: .string),
+      .field(post.title, is: .required, ofType: .string),
+      .belongsTo(post.blog, is: .optional, ofType: Blog.self, targetNames: [\\"blogPostsId\\"]),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post),
+      .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var title: FieldPath<String>   {
+      string(\\"title\\") 
+    }
+  public var blog: ModelPath<Blog>   {
+      Blog.Path(name: \\"blog\\", parent: self) 
+    }
+  public var comments: ModelPath<Comment>   {
+      Comment.Path(name: \\"comments\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Post.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let id: String
+  public var title: String
+  internal var _blog: LazyReference<Blog>
+  public var blog: Blog?   {
+      get async throws { 
+        try await _blog.get()
+      } 
+    }
+  public var comments: List<Comment>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      blog: Blog? = nil,
+      comments: List<Comment>? = []) {
+    self.init(id: id,
+      title: title,
+      blog: blog,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      blog: Blog? = nil,
+      comments: List<Comment>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self._blog = LazyReference(blog)
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setBlog(_ blog: Blog? = nil) {
+    self._blog = LazyReference(blog)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      _blog = try values.decodeIfPresent(LazyReference<Blog>.self, forKey: .blog) ?? LazyReference(identifiers: nil)
+      comments = try values.decodeIfPresent(List<Comment>?.self, forKey: .comments) ?? .init()
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(_blog, forKey: .blog)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}",
+}
+`;
+
+exports[`generateModelsSync targets basic typescript 1`] = `
+Object {
+  "index.ts": "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+import { initSchema } from \\"@aws-amplify/datastore\\";
+
+import { schema } from \\"./schema\\";
+
+
+
+type EagerBlogModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Blog, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly posts?: (PostModel | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+type LazyBlogModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Blog, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly name: string;
+  readonly posts: AsyncCollection<PostModel>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+export declare type BlogModel = LazyLoading extends LazyLoadingDisabled ? EagerBlogModel : LazyBlogModel
+
+export declare const BlogModel: (new (init: ModelInit<BlogModel>) => BlogModel) & {
+  copyOf(source: BlogModel, mutator: (draft: MutableModel<BlogModel>) => MutableModel<BlogModel> | void): BlogModel;
+}
+
+type EagerPostModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Post, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly blog?: BlogModel | null;
+  readonly comments?: (CommentModel | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly blogPostsId?: string | null;
+}
+
+type LazyPostModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Post, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly blog: AsyncItem<BlogModel | undefined>;
+  readonly comments: AsyncCollection<CommentModel>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly blogPostsId?: string | null;
+}
+
+export declare type PostModel = LazyLoading extends LazyLoadingDisabled ? EagerPostModel : LazyPostModel
+
+export declare const PostModel: (new (init: ModelInit<PostModel>) => PostModel) & {
+  copyOf(source: PostModel, mutator: (draft: MutableModel<PostModel>) => MutableModel<PostModel> | void): PostModel;
+}
+
+type EagerCommentModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Comment, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly post?: PostModel | null;
+  readonly content: string;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly postCommentsId?: string | null;
+}
+
+type LazyCommentModel = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<Comment, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly post: AsyncItem<PostModel | undefined>;
+  readonly content: string;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly postCommentsId?: string | null;
+}
+
+export declare type CommentModel = LazyLoading extends LazyLoadingDisabled ? EagerCommentModel : LazyCommentModel
+
+export declare const CommentModel: (new (init: ModelInit<CommentModel>) => CommentModel) & {
+  copyOf(source: CommentModel, mutator: (draft: MutableModel<CommentModel>) => MutableModel<CommentModel> | void): CommentModel;
+}
+
+
+
+const { Blog, Post, Comment } = initSchema(schema) as {
+  Blog: PersistentModelConstructor<BlogModel>;
+  Post: PersistentModelConstructor<PostModel>;
+  Comment: PersistentModelConstructor<CommentModel>;
+};
+
+export {
+  Blog,
+  Post,
+  Comment
+};",
+  "schema.ts": "import { Schema } from \\"@aws-amplify/datastore\\";
+
+export const schema: Schema = {
+    \\"models\\": {
+        \\"Blog\\": {
+            \\"name\\": \\"Blog\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"posts\\": {
+                    \\"name\\": \\"posts\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Blogs\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"blog\\": {
+                    \\"name\\": \\"blog\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Blog\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"blogPostsId\\"
+                        ]
+                    }
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"blogPostsId\\": {
+                    \\"name\\": \\"blogPostsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsId\\"
+                        ]
+                    }
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"920118e6cbedacf9fdf58bb983d59a94\\"
+};",
+}
+`;
+
+exports[`generateModelsSync targets improve pluralization swift 1`] = `
+Object {
+  "AmplifyModels.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+// Contains the set of classes that conforms to the \`Model\` protocol. 
+
+final public class AmplifyModels: AmplifyModelRegistration {
+  public let version: String = \\"165944a36979cd395e3b22145bbfeff0\\"
+  
+  public func registerModels(registry: ModelRegistry.Type) {
+    ModelRegistry.register(modelType: Blog.self)
+    ModelRegistry.register(modelType: Post.self)
+    ModelRegistry.register(modelType: Comment.self)
+  }
+}",
+  "Blog+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Blog {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case posts
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let blog = Blog.keys
+    
+    model.listPluralName = \\"Blogs\\"
+    model.syncPluralName = \\"Blogs\\"
+    
+    model.attributes(
+      .primaryKey(fields: [blog.id])
+    )
+    
+    model.fields(
+      .field(blog.id, is: .required, ofType: .string),
+      .field(blog.name, is: .required, ofType: .string),
+      .hasMany(blog.posts, is: .optional, ofType: Post.self, associatedWith: Post.keys.blog),
+      .field(blog.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(blog.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Blog> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Blog: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Blog {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var name: FieldPath<String>   {
+      string(\\"name\\") 
+    }
+  public var posts: ModelPath<Post>   {
+      Post.Path(name: \\"posts\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Blog.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Blog: Model {
+  public let id: String
+  public var name: String
+  public var posts: List<Post>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      name: String,
+      posts: List<Post>? = []) {
+    self.init(id: id,
+      name: name,
+      posts: posts,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      name: String,
+      posts: List<Post>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.name = name
+      self.posts = posts
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}",
+  "Comment+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case post
+    case content
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment = Comment.keys
+    
+    model.listPluralName = \\"Comments\\"
+    model.syncPluralName = \\"Comments\\"
+    
+    model.attributes(
+      .primaryKey(fields: [comment.id])
+    )
+    
+    model.fields(
+      .field(comment.id, is: .required, ofType: .string),
+      .belongsTo(comment.post, is: .optional, ofType: Post.self, targetNames: [\\"postCommentsId\\"]),
+      .field(comment.content, is: .required, ofType: .string),
+      .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var post: ModelPath<Post>   {
+      Post.Path(name: \\"post\\", parent: self) 
+    }
+  public var content: FieldPath<String>   {
+      string(\\"content\\") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Comment.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment: Model {
+  public let id: String
+  internal var _post: LazyReference<Post>
+  public var post: Post?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  public var content: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      post: Post? = nil,
+      content: String) {
+    self.init(id: id,
+      post: post,
+      content: content,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      post: Post? = nil,
+      content: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self._post = LazyReference(post)
+      self.content = content
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post? = nil) {
+    self._post = LazyReference(post)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      _post = try values.decodeIfPresent(LazyReference<Post>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      content = try values.decode(String.self, forKey: .content)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(_post, forKey: .post)
+      try container.encode(content, forKey: .content)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}",
+  "Post+Schema.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case blog
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post = Post.keys
+    
+    model.listPluralName = \\"Posts\\"
+    model.syncPluralName = \\"Posts\\"
+    
+    model.attributes(
+      .primaryKey(fields: [post.id])
+    )
+    
+    model.fields(
+      .field(post.id, is: .required, ofType: .string),
+      .field(post.title, is: .required, ofType: .string),
+      .belongsTo(post.blog, is: .optional, ofType: Blog.self, targetNames: [\\"blogPostsId\\"]),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post),
+      .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var title: FieldPath<String>   {
+      string(\\"title\\") 
+    }
+  public var blog: ModelPath<Blog>   {
+      Blog.Path(name: \\"blog\\", parent: self) 
+    }
+  public var comments: ModelPath<Comment>   {
+      Comment.Path(name: \\"comments\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}",
+  "Post.swift": "// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let id: String
+  public var title: String
+  internal var _blog: LazyReference<Blog>
+  public var blog: Blog?   {
+      get async throws { 
+        try await _blog.get()
+      } 
+    }
+  public var comments: List<Comment>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      blog: Blog? = nil,
+      comments: List<Comment>? = []) {
+    self.init(id: id,
+      title: title,
+      blog: blog,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      blog: Blog? = nil,
+      comments: List<Comment>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self._blog = LazyReference(blog)
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setBlog(_ blog: Blog? = nil) {
+    self._blog = LazyReference(blog)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      _blog = try values.decodeIfPresent(LazyReference<Blog>.self, forKey: .blog) ?? LazyReference(identifiers: nil)
+      comments = try values.decodeIfPresent(List<Comment>?.self, forKey: .comments) ?? .init()
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(_blog, forKey: .blog)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}",
+}
+`;

--- a/packages/graphql-generator/src/__tests__/modelsSync.test.ts
+++ b/packages/graphql-generator/src/__tests__/modelsSync.test.ts
@@ -10,7 +10,8 @@ describe('generateModelsSync', () => {
           schema: readSchema('blog-model.graphql'),
           target,
         };
-        const models = await generateModelsSync(options);
+        const models = generateModelsSync(options);
+        expect(models).not.toBeInstanceOf(Promise);
         expect(models).toMatchSnapshot();
       });
     });
@@ -21,7 +22,8 @@ describe('generateModelsSync', () => {
         target: 'swift',
         improvePluralization: true,
       };
-      const models = await generateModelsSync(options);
+      const models = generateModelsSync(options);
+      expect(models).not.toBeInstanceOf(Promise);
       expect(models).toMatchSnapshot();
     });
   });
@@ -39,7 +41,8 @@ describe('generateModelsSync', () => {
         directive @customField on FIELD_DEFINITION
       `,
     };
-    const models = await generateModelsSync(options);
+    const models = generateModelsSync(options);
+    expect(models).not.toBeInstanceOf(Promise);
     expect(models).toMatchSnapshot();
   });
 });

--- a/packages/graphql-generator/src/codegenSync/codegen.ts
+++ b/packages/graphql-generator/src/codegenSync/codegen.ts
@@ -7,7 +7,7 @@ import {
   createNoopProfiler,
 } from '@graphql-codegen/plugin-helpers';
 import { visit, DefinitionNode, Kind, print, NameNode, specifiedRules, DocumentNode } from 'graphql';
-import { executePlugin } from './execute-plugin.js';
+import { executePlugin } from './execute-plugin';
 import { validateGraphQlDocuments, Source, asArray } from '@graphql-tools/utils';
 
 import { mergeSchemas } from '@graphql-tools/schema';
@@ -19,7 +19,7 @@ import {
   prioritize,
   shouldValidateDocumentsAgainstSchema,
   shouldValidateDuplicateDocuments,
-} from './utils.js';
+} from './utils';
 
 export async function codegen(options: Types.GenerateOptions): Promise<string> {
   const documents = options.documents || [];

--- a/packages/graphql-generator/src/codegenSync/index.ts
+++ b/packages/graphql-generator/src/codegenSync/index.ts
@@ -1,2 +1,2 @@
-export { codegen } from './codegen.js';
-export { executePlugin, ExecutePluginOptions } from './execute-plugin.js';
+export { codegen } from './codegen';
+export { executePlugin, ExecutePluginOptions } from './execute-plugin';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,7 +5028,7 @@
     "@graphql-tools/utils" "^9.2.1"
     tslib "^2.4.0"
 
-"@graphql-tools/schema@^9.0.0":
+"@graphql-tools/schema@^9.0.0", "@graphql-tools/schema@^9.0.19":
   version "9.0.19"
   resolved "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz#c4ad373b5e1b8a0cf365163435b7d236ebdd06e7"
   integrity sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==


### PR DESCRIPTION
#### Description of changes
**Make `generateModelsSync` actually non-async**
- Modify `codegen` to be non-async by stripping out the profiler
- Modify plugins to add a `presetSync` that has all sync (not-async) plugins
- Update types to remove promises from plugin return type

As a result we can `generateModels` without any `await`:
```
  const models = generateModelsSync({
    schema: schema.transform().schema,
    target: "introspection",
  });

  return models["model-introspection.json"];
```

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
