### PR TITLE
feat: Add generateModelsSync using a local copy of codegen (not actua…

### DIFF
--- a/packages/graphql-generator/package.json
+++ b/packages/graphql-generator/package.json
@@ -29,6 +29,9 @@
     "@aws-amplify/graphql-docs-generator": "4.2.1",
     "@aws-amplify/graphql-types-generator": "3.6.0",
     "@graphql-codegen/core": "^2.6.6",
+    "@graphql-tools/schema": "^9.0.19",
+    "@graphql-tools/utils": "^9.2.1",
+    "@graphql-codegen/plugin-helpers": "^3.1.2",
     "@graphql-tools/apollo-engine-loader": "^8.0.0",
     "graphql": "^15.5.0",
     "prettier": "^1.19.1"

--- a/packages/graphql-generator/src/__tests__/modelsSync.test.ts
+++ b/packages/graphql-generator/src/__tests__/modelsSync.test.ts
@@ -1,0 +1,45 @@
+import { generateModelsSync, GenerateModelsOptions, ModelsTarget } from '..';
+import { readSchema } from './utils';
+
+describe('generateModelsSync', () => {
+  describe('targets', () => {
+    const targets: ModelsTarget[] = ['java', 'swift', 'javascript', 'typescript', 'dart', 'introspection'];
+    targets.forEach(target => {
+      test(`basic ${target}`, async () => {
+        const options: GenerateModelsOptions = {
+          schema: readSchema('blog-model.graphql'),
+          target,
+        };
+        const models = await generateModelsSync(options);
+        expect(models).toMatchSnapshot();
+      });
+    });
+
+    test(`improve pluralization swift`, async () => {
+      const options: GenerateModelsOptions = {
+        schema: readSchema('blog-model.graphql'),
+        target: 'swift',
+        improvePluralization: true,
+      };
+      const models = await generateModelsSync(options);
+      expect(models).toMatchSnapshot();
+    });
+  });
+
+  test('does not fail on custom directives', async () => {
+    const options: GenerateModelsOptions = {
+      schema: `
+        type Blog @customModel {
+          id: ID!
+          name: String! @customField
+        }`,
+      target: 'introspection',
+      directives: `
+        directive @customModel on OBJECT
+        directive @customField on FIELD_DEFINITION
+      `,
+    };
+    const models = await generateModelsSync(options);
+    expect(models).toMatchSnapshot();
+  });
+});

--- a/packages/graphql-generator/src/codegenSync/codegen.ts
+++ b/packages/graphql-generator/src/codegenSync/codegen.ts
@@ -1,0 +1,310 @@
+import {
+  Types,
+  isComplexPluginOutput,
+  federationSpec,
+  getCachedDocumentNodeFromSchema,
+  AddToSchemaResult,
+  createNoopProfiler,
+} from '@graphql-codegen/plugin-helpers';
+import { visit, DefinitionNode, Kind, print, NameNode, specifiedRules, DocumentNode } from 'graphql';
+import { executePlugin } from './execute-plugin.js';
+import { validateGraphQlDocuments, Source, asArray } from '@graphql-tools/utils';
+
+import { mergeSchemas } from '@graphql-tools/schema';
+import {
+  extractHashFromSchema,
+  getSkipDocumentsValidationOption,
+  hasFederationSpec,
+  pickFlag,
+  prioritize,
+  shouldValidateDocumentsAgainstSchema,
+  shouldValidateDuplicateDocuments,
+} from './utils.js';
+
+export async function codegen(options: Types.GenerateOptions): Promise<string> {
+  const documents = options.documents || [];
+  const profiler = options.profiler ?? createNoopProfiler();
+
+  const skipDocumentsValidation = getSkipDocumentsValidationOption(options);
+
+  if (documents.length > 0 && shouldValidateDuplicateDocuments(skipDocumentsValidation)) {
+    await profiler.run(async () => validateDuplicateDocuments(documents), 'validateDuplicateDocuments');
+  }
+
+  const pluginPackages = Object.keys(options.pluginMap).map(key => options.pluginMap[key]);
+
+  // merged schema with parts added by plugins
+  const additionalTypeDefs: AddToSchemaResult[] = [];
+  for (const plugin of pluginPackages) {
+    const addToSchema =
+      typeof plugin.addToSchema === 'function' ? plugin.addToSchema(options.config) : plugin.addToSchema;
+
+    if (addToSchema) {
+      additionalTypeDefs.push(addToSchema);
+    }
+  }
+
+  const federationInConfig: boolean = pickFlag('federation', options.config);
+  const isFederation = prioritize(federationInConfig, false);
+
+  if (isFederation && !hasFederationSpec(options.schemaAst || options.schema)) {
+    additionalTypeDefs.push(federationSpec);
+  }
+
+  // Use mergeSchemas, only if there is no GraphQLSchema provided or the schema should be extended
+  const mergeNeeded = !options.schemaAst || additionalTypeDefs.length > 0;
+
+  const schemaInstance = await profiler.run(async () => {
+    return mergeNeeded
+      ? mergeSchemas({
+          // If GraphQLSchema provided, use it
+          schemas: options.schemaAst ? [options.schemaAst] : [],
+          // If GraphQLSchema isn't provided but DocumentNode is, use it to get the final GraphQLSchema
+          typeDefs: options.schemaAst ? additionalTypeDefs : [options.schema, ...additionalTypeDefs],
+          convertExtensions: true,
+          assumeValid: true,
+          assumeValidSDL: true,
+          ...options.config,
+        } as any)
+      : options.schemaAst;
+  }, 'Create schema instance');
+
+  const schemaDocumentNode =
+    mergeNeeded || !options.schema ? getCachedDocumentNodeFromSchema(schemaInstance!) : options.schema;
+
+  if (schemaInstance && documents.length > 0 && shouldValidateDocumentsAgainstSchema(skipDocumentsValidation)) {
+    const ignored = ['NoUnusedFragments', 'NoUnusedVariables', 'KnownDirectives'];
+    if (typeof skipDocumentsValidation === 'object' && skipDocumentsValidation.ignoreRules) {
+      ignored.push(...asArray(skipDocumentsValidation.ignoreRules));
+    }
+    const extraFragments: { importFrom: string; node: DefinitionNode }[] =
+      pickFlag('externalFragments', options.config) || [];
+
+    const errors = await profiler.run(() => {
+      const fragments = extraFragments.map(f => ({
+        location: f.importFrom,
+        document: { kind: Kind.DOCUMENT, definitions: [f.node] } as DocumentNode,
+      }));
+      const rules = specifiedRules.filter(rule => !ignored.some(ignoredRule => rule.name.startsWith(ignoredRule)));
+      const schemaHash = extractHashFromSchema(schemaInstance);
+
+      if (!schemaHash || !options.cache || documents.some(d => typeof d.hash !== 'string')) {
+        return Promise.resolve(
+          validateGraphQlDocuments(
+            schemaInstance,
+            [...documents.flatMap(d => d.document!), ...fragments.flatMap(f => f.document)],
+            rules
+          )
+        );
+      }
+
+      const cacheKey = [schemaHash]
+        .concat(documents.map(doc => doc.hash!))
+        .concat(JSON.stringify(fragments))
+        .join(',');
+
+      return options.cache('documents-validation', cacheKey, () =>
+        Promise.resolve(
+          validateGraphQlDocuments(
+            schemaInstance,
+            [...documents.flatMap(d => d.document!), ...fragments.flatMap(f => f.document)],
+            rules
+          )
+        )
+      );
+    }, 'Validate documents against schema');
+
+    if (errors.length > 0) {
+      throw new Error(
+        `GraphQL Document Validation failed with ${errors.length} errors;
+  ${errors.map((error, index) => `Error ${index}: ${error.stack}`).join('\n\n')}`
+      );
+    }
+  }
+
+  const prepend: Set<string> = new Set<string>();
+  const append: Set<string> = new Set<string>();
+
+  const output = await Promise.all(
+    options.plugins.map(async plugin => {
+      const name = Object.keys(plugin)[0];
+      const pluginPackage = options.pluginMap[name];
+      const pluginConfig = plugin[name] || {};
+
+      const execConfig =
+        typeof pluginConfig !== 'object'
+          ? pluginConfig
+          : {
+              ...options.config,
+              ...pluginConfig,
+            };
+
+      const result = await profiler.run(
+        () =>
+          executePlugin(
+            {
+              name,
+              config: execConfig,
+              parentConfig: options.config,
+              schema: schemaDocumentNode,
+              schemaAst: schemaInstance,
+              documents: options.documents,
+              outputFilename: options.filename,
+              allPlugins: options.plugins,
+              skipDocumentsValidation: options.skipDocumentsValidation,
+              pluginContext: options.pluginContext,
+              profiler,
+            },
+            pluginPackage
+          ),
+        `Plugin ${name}`
+      );
+
+      if (typeof result === 'string') {
+        return result || '';
+      }
+      if (isComplexPluginOutput(result)) {
+        if (result.append && result.append.length > 0) {
+          for (const item of result.append) {
+            if (item) {
+              append.add(item);
+            }
+          }
+        }
+
+        if (result.prepend && result.prepend.length > 0) {
+          for (const item of result.prepend) {
+            if (item) {
+              prepend.add(item);
+            }
+          }
+        }
+        return result.content || '';
+      }
+
+      return '';
+    })
+  );
+
+  return [...sortPrependValues(Array.from(prepend.values())), ...output, ...Array.from(append.values())]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function resolveCompareValue(a: string) {
+  if (a.startsWith('/*') || a.startsWith('//') || a.startsWith(' *') || a.startsWith(' */') || a.startsWith('*/')) {
+    return 0;
+  }
+  if (a.startsWith('package')) {
+    return 1;
+  }
+  if (a.startsWith('import')) {
+    return 2;
+  }
+  return 3;
+}
+
+export function sortPrependValues(values: string[]): string[] {
+  return values.sort((a: string, b: string) => {
+    const aV = resolveCompareValue(a);
+    const bV = resolveCompareValue(b);
+
+    if (aV < bV) {
+      return -1;
+    }
+    if (aV > bV) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
+function validateDuplicateDocuments(files: Types.DocumentFile[]) {
+  // duplicated names
+  const definitionMap: {
+    [kind: string]: {
+      [name: string]: {
+        paths: Set<string>;
+        contents: Set<string>;
+      };
+    };
+  } = {};
+
+  function addDefinition(
+    file: Source,
+    node: DefinitionNode & { name?: NameNode },
+    deduplicatedDefinitions: Set<DefinitionNode>
+  ) {
+    if (typeof node.name !== 'undefined') {
+      if (!definitionMap[node.kind]) {
+        definitionMap[node.kind] = {};
+      }
+      if (!definitionMap[node.kind][node.name.value]) {
+        definitionMap[node.kind][node.name.value] = {
+          paths: new Set(),
+          contents: new Set(),
+        };
+      }
+
+      const definitionKindMap = definitionMap[node.kind];
+
+      const length = definitionKindMap[node.name.value].contents.size;
+      definitionKindMap[node.name.value].paths.add(file.location!);
+      definitionKindMap[node.name.value].contents.add(print(node));
+      if (length === definitionKindMap[node.name.value].contents.size) {
+        return null;
+      }
+    }
+    return deduplicatedDefinitions.add(node);
+  }
+
+  files.forEach(file => {
+    const deduplicatedDefinitions = new Set<DefinitionNode>();
+    visit(file.document!, {
+      OperationDefinition(node) {
+        addDefinition(file, node, deduplicatedDefinitions);
+      },
+      FragmentDefinition(node) {
+        addDefinition(file, node, deduplicatedDefinitions);
+      },
+    });
+    (file.document as any).definitions = Array.from(deduplicatedDefinitions);
+  });
+
+  const kinds = Object.keys(definitionMap);
+
+  kinds.forEach(kind => {
+    const definitionKindMap = definitionMap[kind];
+    const names = Object.keys(definitionKindMap);
+    if (names.length) {
+      const duplicated = names.filter(name => definitionKindMap[name].contents.size > 1);
+
+      if (!duplicated.length) {
+        return;
+      }
+
+      const list = duplicated
+        .map(name =>
+          `
+        * ${name} found in:
+          ${[...definitionKindMap[name].paths]
+            .map(filepath => {
+              return `
+              - ${filepath}
+            `.trimRight();
+            })
+            .join('')}
+    `.trimRight()
+        )
+        .join('');
+
+      const definitionKindName = kind.replace('Definition', '').toLowerCase();
+      throw new Error(
+        `Not all ${definitionKindName}s have an unique name: ${duplicated.join(', ')}: \n
+          ${list}
+        `
+      );
+    }
+  });
+}

--- a/packages/graphql-generator/src/codegenSync/execute-plugin.ts
+++ b/packages/graphql-generator/src/codegenSync/execute-plugin.ts
@@ -1,0 +1,86 @@
+import { Types, CodegenPlugin, Profiler, createNoopProfiler } from '@graphql-codegen/plugin-helpers';
+import { DocumentNode, GraphQLSchema, buildASTSchema } from 'graphql';
+
+export interface ExecutePluginOptions {
+  name: string;
+  config: Types.PluginConfig;
+  parentConfig: Types.PluginConfig;
+  schema: DocumentNode;
+  schemaAst?: GraphQLSchema;
+  documents: Types.DocumentFile[];
+  outputFilename: string;
+  allPlugins: Types.ConfiguredPlugin[];
+  skipDocumentsValidation?: Types.SkipDocumentsValidationOptions;
+  pluginContext?: { [key: string]: any };
+  profiler?: Profiler;
+}
+
+export async function executePlugin(options: ExecutePluginOptions, plugin: CodegenPlugin): Promise<Types.PluginOutput> {
+  if (!plugin || !plugin.plugin || typeof plugin.plugin !== 'function') {
+    throw new Error(
+      `Invalid Custom Plugin "${options.name}" \n
+        Plugin ${options.name} does not export a valid JS object with "plugin" function.
+
+        Make sure your custom plugin is written in the following form:
+
+        module.exports = {
+          plugin: (schema, documents, config) => {
+            return 'my-custom-plugin-content';
+          },
+        };
+        `
+    );
+  }
+
+  const outputSchema: GraphQLSchema = options.schemaAst || buildASTSchema(options.schema, options.config as any);
+  const documents = options.documents || [];
+  const pluginContext = options.pluginContext || {};
+  const profiler = options.profiler ?? createNoopProfiler();
+
+  if (plugin.validate && typeof plugin.validate === 'function') {
+    try {
+      // FIXME: Sync validate signature with plugin signature
+      await profiler.run(
+        async () =>
+          plugin!.validate!(
+            outputSchema,
+            documents,
+            options.config,
+            options.outputFilename,
+            options.allPlugins,
+            pluginContext
+          ),
+        `Plugin ${options.name} validate`
+      );
+    } catch (e) {
+        let error: Error;
+        if (!(e instanceof Error)) {
+          error = new Error(String(e));
+        } else {
+          error = e;
+        }
+        throw new Error(
+          `Plugin "${options.name}" validation failed: \n
+              ${error.message}
+            `
+        );
+    }
+  }
+
+  return profiler.run(
+    () =>
+      Promise.resolve(
+        plugin.plugin(
+          outputSchema,
+          documents,
+          typeof options.config === 'object' ? { ...options.config } : options.config,
+          {
+            outputFile: options.outputFilename,
+            allPlugins: options.allPlugins,
+            pluginContext,
+          }
+        )
+      ),
+    `Plugin ${options.name} execution`
+  );
+}

--- a/packages/graphql-generator/src/codegenSync/index.ts
+++ b/packages/graphql-generator/src/codegenSync/index.ts
@@ -1,0 +1,2 @@
+export { codegen } from './codegen.js';
+export { executePlugin, ExecutePluginOptions } from './execute-plugin.js';

--- a/packages/graphql-generator/src/codegenSync/utils.ts
+++ b/packages/graphql-generator/src/codegenSync/utils.ts
@@ -1,0 +1,86 @@
+import { Types } from '@graphql-codegen/plugin-helpers';
+import { isDocumentNode } from '@graphql-tools/utils';
+import { DocumentNode, GraphQLSchema, isSchema, Kind } from 'graphql';
+
+export function isObjectMap(obj: any): obj is Types.PluginConfig<any> {
+  return obj && typeof obj === 'object' && !Array.isArray(obj);
+}
+
+export function prioritize<T>(...values: T[]): T {
+  const picked = values.find(val => typeof val === 'boolean');
+
+  if (typeof picked !== 'boolean') {
+    return values[values.length - 1];
+  }
+
+  return picked;
+}
+
+export function pickFlag<TConfig, TKey extends keyof TConfig>(flag: TKey, config: TConfig): TConfig[TKey] | undefined {
+  return isObjectMap(config) ? config[flag] : undefined;
+}
+
+export function shouldValidateDuplicateDocuments(
+  skipDocumentsValidationOption: Types.GenerateOptions['skipDocumentsValidation']
+) {
+  // If the value is true, skip all
+  if (skipDocumentsValidationOption === true) {
+    return false;
+  }
+  // If the value is object with the specific flag, only skip this one
+  if (typeof skipDocumentsValidationOption === 'object' && skipDocumentsValidationOption.skipDuplicateValidation) {
+    return false;
+  }
+  // If the value is falsy or the specific flag is not set, validate
+  return true;
+}
+
+export function shouldValidateDocumentsAgainstSchema(
+  skipDocumentsValidationOption: Types.GenerateOptions['skipDocumentsValidation']
+) {
+  // If the value is true, skip all
+  if (skipDocumentsValidationOption === true) {
+    return false;
+  }
+  // If the value is object with the specific flag, only skip this one
+  if (typeof skipDocumentsValidationOption === 'object' && skipDocumentsValidationOption.skipValidationAgainstSchema) {
+    return false;
+  }
+  // If the value is falsy or the specific flag is not set, validate
+  return true;
+}
+
+export function getSkipDocumentsValidationOption(options: Types.GenerateOptions): Types.SkipDocumentsValidationOptions {
+  // If the value is set on the root level
+  if (options.skipDocumentsValidation) {
+    return options.skipDocumentsValidation;
+  }
+  // If the value is set under `config` property
+  const flagFromConfig: Types.SkipDocumentsValidationOptions = pickFlag('skipDocumentsValidation', options.config);
+  if (flagFromConfig) {
+    return flagFromConfig;
+  }
+  return false;
+}
+
+const federationDirectives = ['key', 'requires', 'provides', 'external'];
+
+export function hasFederationSpec(schemaOrAST: GraphQLSchema | DocumentNode) {
+  if (isSchema(schemaOrAST)) {
+    return federationDirectives.some(directive => schemaOrAST.getDirective(directive));
+  }
+  if (isDocumentNode(schemaOrAST)) {
+    return schemaOrAST.definitions.some(
+      def => def.kind === Kind.DIRECTIVE_DEFINITION && federationDirectives.includes(def.name.value)
+    );
+  }
+  return false;
+}
+
+export function extractHashFromSchema(schema: GraphQLSchema): string | null {
+  if (!schema.extensions) {
+    schema.extensions = {};
+  }
+
+  return (schema.extensions['hash'] as string) ?? null;
+}

--- a/packages/graphql-generator/src/index.ts
+++ b/packages/graphql-generator/src/index.ts
@@ -1,4 +1,5 @@
 export { generateModels } from './models';
+export { generateModelsSync } from './modelsSync';
 export { generateStatements } from './statements';
 export { generateTypes } from './types';
 

--- a/packages/graphql-generator/src/modelsSync.ts
+++ b/packages/graphql-generator/src/modelsSync.ts
@@ -2,13 +2,13 @@ import * as path from 'path';
 import { parse } from 'graphql';
 import * as appSyncDataStoreCodeGen from '@aws-amplify/appsync-modelgen-plugin';
 import { DefaultDirectives } from '@aws-amplify/graphql-directives';
-import { codegen } from '@graphql-codegen/core';
+import { codegen } from './codegenSync';
 import { GenerateModelsOptions, GeneratedOutput } from './typescript';
 const { version: packageVersion } = require('../package.json');
 
 const directiveDefinitions = DefaultDirectives.map(directive => directive.definition).join('\n');
 
-export async function generateModels(options: GenerateModelsOptions): Promise<GeneratedOutput> {
+export async function generateModelsSync(options: GenerateModelsOptions): Promise<GeneratedOutput> {
   const {
     schema,
     target,


### PR DESCRIPTION
#### Description of changes
**Copy ~400 lines from `@graphql-codegen/core` into our package for future modification**

This first change moves the content of `@graphql-codegen/core` into a subfolder and add `generateModelsSync` as an export of `@aws-amplify/graphql-generator`.

> [!NOTE] 
> This change does not modify the `codegen` code copied across, except in ways that resolve typescript errors (mostly `!` to resolve optional values without changing implementation details). The work to change the copied code is captured in [this PR](https://github.com/stocaaro/amplify-codegen/pull/1)

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
